### PR TITLE
Add search filter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ function App() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedVideoId, setSelectedVideoId] = useState('')
   const [modalTitle, setModalTitle] = useState(''); // State for modal title
+  const [searchTerm, setSearchTerm] = useState('');
 
 
   const openModal = (videoId, title) => {
@@ -37,6 +38,15 @@ function App() {
     };
   }, [isModalOpen]);
 
+  const filteredMoves = movesData
+    .map((category) => ({
+      ...category,
+      moves: category.moves.filter((m) =>
+        `${m.name} ${m.note}`.toLowerCase().includes(searchTerm.toLowerCase())
+      ),
+    }))
+    .filter((category) => category.moves.length > 0 || searchTerm === '');
+
   return (
     <section className="mx-auto max-w-3xl px-4 sm:px-6 xl:max-w-5xl xl:px-0">
 
@@ -54,7 +64,15 @@ function App() {
         <a target="_blank" className="print:hidden text-purple-600 dark:text-purple-300 underline" href="https://waynegraham.github.io/bjj-study-guide/gracie-jiu-jitsu_compress.pdf">Reference</a>
       </p>
 
-      {movesData.map((move) => ( // Map through moves data
+      <input
+        aria-label="search"
+        type="text"
+        placeholder="Search"
+        value={searchTerm}
+        onChange={(e) => setSearchTerm(e.target.value)}
+        className="mt-4 mb-6 w-full rounded border p-2 text-black"
+      />
+      {filteredMoves.map((move) => ( // Map through moves data
         <div key={move.label}>
           <h2 className="my-3 text-xl print:my-0 text-gray-900 dark:text-gray-300">{move.label}</h2>
           <ul className='list-disc ps-5 mt-2 space-y-1 dark:text-gray-300'>

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -13,3 +13,11 @@ test('opens modal when clicking a move', () => {
   fireEvent.click(link);
   expect(screen.getByText('Close')).toBeInTheDocument();
 });
+
+test('filters moves when searching', () => {
+  render(<App />);
+  const input = screen.getByLabelText('search');
+  fireEvent.change(input, { target: { value: 'Sucker' } });
+  expect(screen.getByText('Sucker Punch Defense')).toBeInTheDocument();
+  expect(screen.queryByText('Close the gap')).not.toBeInTheDocument();
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig({
     postcss: './postcss.config.js',
   },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    globals: true
   }
 })


### PR DESCRIPTION
## Summary
- add search box and filter moves in App
- test searching for a move
- enable Vitest globals for existing tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68474cc0c598832d97c833e7f9c2f5ff